### PR TITLE
Fix Warm White 20 hex value

### DIFF
--- a/_ibm-colors.scss
+++ b/_ibm-colors.scss
@@ -323,9 +323,9 @@ $__ibm-color-palettes: (
     40: #ecf0f2
   ),
   'warm-white': (
-    core: #fdfbfb,
-    10: #fdfbfb,
-    20: #faf7f7,
+    core: #fbfbfb,
+    10: #fbfbfb,
+    20: #fdfbfb,
     30: #f7f5f5,
     40: #f2eeee
   ),

--- a/_ibm-colors.scss
+++ b/_ibm-colors.scss
@@ -325,7 +325,7 @@ $__ibm-color-palettes: (
   'warm-white': (
     core: #fdfbfb,
     10: #fdfbfb,
-    20: #fdfbfb,
+    20: #faf7f7,
     30: #f7f5f5,
     40: #f2eeee
   ),

--- a/ibm-colors.json
+++ b/ibm-colors.json
@@ -159,7 +159,7 @@
   "warm-white": {
     "core": "#fdfbfb",
     "10": "#fdfbfb",
-    "20": "#fdfbfb",
+    "20": "#faf7f7",
     "30": "#f7f5f5",
     "40": "#f2eeee"
   },

--- a/ibm-colors.json
+++ b/ibm-colors.json
@@ -157,9 +157,9 @@
     "40": "#ecf0f2"
   },
   "warm-white": {
-    "core": "#fdfbfb",
-    "10": "#fdfbfb",
-    "20": "#faf7f7",
+    "core": "#fbfbfb",
+    "10": "#fbfbfb",
+    "20": "#fdfbfb",
     "30": "#f7f5f5",
     "40": "#f2eeee"
   },

--- a/source/colors.js
+++ b/source/colors.js
@@ -213,9 +213,9 @@ module.exports = {
     {
       name: 'warm-white',
       values: [
-        { tone: 'core', value: '#fdfbfb' },
-        { tone: '10', value: '#fdfbfb' },
-        { tone: '20', value: '#faf7f7' },
+        { tone: 'core', value: '#fbfbfb' },
+        { tone: '10', value: '#fbfbfb' },
+        { tone: '20', value: '#fdfbfb' },
         { tone: '30', value: '#f7f5f5' },
         { tone: '40', value: '#f2eeee' }
       ]

--- a/source/colors.js
+++ b/source/colors.js
@@ -5,7 +5,7 @@
 module.exports = {
 
   palettes: [
-  
+
     // each entry in this array is an object with the following properties:
     //  * name: the name of the palette; eg 'gray'
     //  * synonyms: (optional) an array of alternative names and spellings,
@@ -13,7 +13,7 @@ module.exports = {
     //  * values: an array of objects each containing two properties:
     //      * tone: the tone amount; eg, '40', '100', 'core'
     //      * value: the color as a six-digit hex value; eg, '#acefed'
-    
+
     {
       name: 'blue',
       values: [
@@ -215,7 +215,7 @@ module.exports = {
       values: [
         { tone: 'core', value: '#fdfbfb' },
         { tone: '10', value: '#fdfbfb' },
-        { tone: '20', value: '#fdfbfb' },
+        { tone: '20', value: '#faf7f7' },
         { tone: '30', value: '#f7f5f5' },
         { tone: '40', value: '#f2eeee' }
       ]


### PR DESCRIPTION
Changes Warm White 20’s hex value from `#fdfbfb` (identical to Warm White 10) to `#faf7f7` (interpolated using the HSL values of Warm White 10 and Warm White 30).

    warm-white-10: #fdfbfb / hsb(360,1,99)
    warm-white-20: #faf7f7 / hsb(360,1,98)
    warm-white-30: #f7f5f5 / hsb(360,1,97)