### PR TITLE
Hotfix/color tint shade

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,6 @@ Returns the specified color from the specified color palette
 //////////////////////////////////////////////////
 
 background: color('blue', 80);     // #1d3649
-background: color('blue', 8);      // #1d3649
-background: color('blue', 'core'); // #4178be
 background: color('blue');         // #4178be
 -- with an alpha
 background: color('blue', 80, $alpha: 0.5); // rgba(29, 54, 73, 0.5)
@@ -106,7 +104,6 @@ Returns a color the specified amount of steps lighter than the given color in th
 //////////////////////////////////////////////////
 
 background: color-tint(color('blue', 80), 20);     // #325c80
-background: color-tint(color('blue', 80), 2);      // #325c80
 background: color-tint(color('blue', 80), 23);     // #325c80
 background: color-tint(color('blue', 80), 25);     // #4178be
 background: color-tint(color('blue', 80), 100);    // #c0e6ff
@@ -129,7 +126,6 @@ Returns a color the specified amount of steps darker than the given color in the
 //////////////////////////////////////////////////
 
 background: color-shade(color('blue', 30), 20);     // #4178be
-background: color-shade(color('blue', 30), 2);      // #4178be
 background: color-shade(color('blue', 30), 23);     // #4178be
 background: color-shade(color('blue', 30), 25);     // #325c80
 background: color-shade(color('blue', 30), 100);    // #010205

--- a/_ibm-colors.scss
+++ b/_ibm-colors.scss
@@ -47,13 +47,23 @@
     @return rgba($grd, $alpha);
   }
 
-  @warn 'Color palette "#{$palette}" not found';
+  $error-message: 'Color palette "#{$palette}" not found';
+  @if not $found-index {
+    @if feature-exists(at-error) {
+      @error $error-message;
+    }
+    @else {
+      @warn $error-message;
+    }
+  }
+
   @return false;
 }
 
 //////////////////////////////
 // Tint and Shade Functions
 //////////////////////////////
+$singles: 'neutral-white', 'cool-white', 'warm-white';
 // Internal helper: finds the palette and key of a color
 @function _ibm-find-color($color) {
   $found-index: false;
@@ -61,10 +71,10 @@
   @each $palette, $vals in $__ibm-color-palettes {
     @if not $found-index {
       @each $key, $clr in $vals {
-	@if $color == $clr and $key != 'core' {
-	  $found-index: $key;
-	  $found-palette: $palette;
-	}
+      	@if $color == $clr and $key != 'core' {
+      	  $found-index: $key;
+      	  $found-palette: $palette;
+      	}
       }
     }
   }
@@ -84,7 +94,7 @@
 
 // Internal helper: transforms amount into base 10, rounding
 @function _ibm-round-tint-shade($amount) {
-  @if $amount < 10 {
+  @if $amount < 1 {
     $amount: $amount * 10;
   }
 
@@ -110,9 +120,23 @@
   $palette: map-get($key, 'palette');
   $move: _ibm-round-tint-shade($amount);
 
-  $index: $index - $move;
-  @if ($index < 10) {
-    $index: 10;
+  @if index($singles, $palette) {
+    $index: $index - ($move / 10);
+    @if $index < 1 {
+      $index: 1;
+    }
+  }
+  @else if $palette == 'black' {
+    $index: 100;
+  }
+  @else if $palette == 'white' {
+    $index: 0;
+  }
+  @else {
+    $index: $index - $move;
+    @if $index < 10 {
+      $index: 1;
+    }
   }
 
   @return color($palette, $index);
@@ -130,9 +154,23 @@
   $palette: map-get($key, 'palette');
   $move: _ibm-round-tint-shade($amount);
 
-  $index: $index + $move;
-  @if ($index > 100) {
+  @if index($singles, $palette) {
+    $index: $index - ($move / 10);
+    @if $index > 4 {
+      $index: 4;
+    }
+  }
+  @else if $palette == 'black' {
     $index: 100;
+  }
+  @else if $palette == 'white' {
+    $index: 0;
+  }
+  @else {
+    $index: $index + $move;
+    @if ($index > 90) {
+      $index: 90;
+    }
   }
 
   @return color($palette, $index);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -147,5 +147,7 @@ gulp.task('templates', ['partials'], () =>
 
 gulp.task('build', [ 'package', 'ase', 'clr', 'sketchpalette' ]);
 
+gulp.task('test', ['build']);
+
 /*--- default task ----------------------------------------------------------*/
 gulp.task('default', [ 'build' ]);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "needs": "^0.8.3"
   },
   "scripts": {
-    "test": "gulp test"
+    "test": "echo \"Error: no test specified\" && exit 0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "needs": "^0.8.3"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 0"
+    "test": "gulp test"
   },
   "repository": {
     "type": "git",

--- a/source/templates/partials/color-functions.scss
+++ b/source/templates/partials/color-functions.scss
@@ -40,13 +40,23 @@
     @return rgba($grd, $alpha);
   }
 
-  @warn 'Color palette "#{$palette}" not found';
+  $error-message: 'Color palette "#{$palette}" not found';
+  @if not $found-index {
+    @if feature-exists(at-error) {
+      @error $error-message;
+    }
+    @else {
+      @warn $error-message;
+    }
+  }
+
   @return false;
 }
 
 //////////////////////////////
 // Tint and Shade Functions
 //////////////////////////////
+$singles: 'neutral-white', 'cool-white', 'warm-white';
 // Internal helper: finds the palette and key of a color
 @function _ibm-find-color($color) {
   $found-index: false;
@@ -54,10 +64,10 @@
   @each $palette, $vals in $__ibm-color-palettes {
     @if not $found-index {
       @each $key, $clr in $vals {
-	@if $color == $clr and $key != 'core' {
-	  $found-index: $key;
-	  $found-palette: $palette;
-	}
+      	@if $color == $clr and $key != 'core' {
+      	  $found-index: $key;
+      	  $found-palette: $palette;
+      	}
       }
     }
   }
@@ -77,7 +87,7 @@
 
 // Internal helper: transforms amount into base 10, rounding
 @function _ibm-round-tint-shade($amount) {
-  @if $amount < 10 {
+  @if $amount < 1 {
     $amount: $amount * 10;
   }
 
@@ -103,9 +113,23 @@
   $palette: map-get($key, 'palette');
   $move: _ibm-round-tint-shade($amount);
 
-  $index: $index - $move;
-  @if ($index < 10) {
-    $index: 10;
+  @if index($singles, $palette) {
+    $index: $index - ($move / 10);
+    @if $index < 1 {
+      $index: 1;
+    }
+  }
+  @else if $palette == 'black' {
+    $index: 100;
+  }
+  @else if $palette == 'white' {
+    $index: 0;
+  }
+  @else {
+    $index: $index - $move;
+    @if $index < 10 {
+      $index: 1;
+    }
   }
 
   @return color($palette, $index);
@@ -123,9 +147,23 @@
   $palette: map-get($key, 'palette');
   $move: _ibm-round-tint-shade($amount);
 
-  $index: $index + $move;
-  @if ($index > 100) {
+  @if index($singles, $palette) {
+    $index: $index - ($move / 10);
+    @if $index > 4 {
+      $index: 4;
+    }
+  }
+  @else if $palette == 'black' {
     $index: 100;
+  }
+  @else if $palette == 'white' {
+    $index: 0;
+  }
+  @else {
+    $index: $index + $move;
+    @if ($index > 90) {
+      $index: 90;
+    }
   }
 
   @return color($palette, $index);


### PR DESCRIPTION
* Fixes `color-tint` and `color-shade` functions
* Fixes documentation in README (holdover from 1.x)
* Adds test to run on Travis